### PR TITLE
Attempt to clean up front page pre blocks

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -18,7 +18,7 @@ layout: home
     %h4 How To Use
   .description
     :markdown
-          $ ./gort
+          $ gort
           NAME:
              gort - Command Line Utility for RobotOps
 
@@ -37,7 +37,7 @@ layout: home
              crazyflie  Configure your Crazyflie
              klaatu barada nikto
              help, h  Shows a list of commands or help for one command
-             
+
           GLOBAL OPTIONS:
              --version, -v  print the version
              --help, -h   show help
@@ -45,7 +45,7 @@ layout: home
     %h6 Scan for connected serial devices:
   .description
     :markdown
-          $ ./gort scan serial
+          $ gort scan serial
           [    0.000000] console [tty0] enabled
 
 .how-to-use
@@ -56,4 +56,4 @@ layout: home
 
     %a{:href=>"/documentation/getting_started/downloads"}
       Download it now for OSX, WINDOWS, & LINUX
-    
+

--- a/source/stylesheets/partials/_home.scss
+++ b/source/stylesheets/partials/_home.scss
@@ -55,8 +55,6 @@
 	}
 
 	pre {
-
-		background: lighten($dark-gray, 10);
 		padding: em(5);
 		margin: 0;
 		@include border-top-radius(5px);


### PR DESCRIPTION
The mixed greys made the pre block hard to read, and the `./` in front of `gort` didn't really need to be there.

![After](http://i.imgur.com/8zmKPcc.png)
